### PR TITLE
Allow user to use Alt SPI pins

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -28,11 +28,14 @@
 
 // Constructor when using hardware SPI.  Faster, but must use SPI pins
 // specific to each board type (e.g. 11,13 for Uno, 51,52 for Mega, etc.)
-ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst)
+ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst, uint8_t mosi, uint8_t sclk, uint8_t miso)
 {
 	_cs   = cs;
 	_dc   = dc;
 	_rst  = rst;
+    _mosi = mosi;
+    _sclk = sclk;
+    _miso = miso;
 	_width    = WIDTH;
 	_height   = HEIGHT;
 	rotation  = 0;
@@ -380,6 +383,13 @@ static const uint8_t init_commands[] = {
 
 void ILI9341_t3::begin(void)
 {
+    // verify SPI pins are valid;
+    if ((_mosi == 11 || _mosi == 7) && (_miso == 12 || _miso == 8) && (_sclk == 13 || _sclk == 14)) {
+        SPI.setMOSI(_mosi);
+        SPI.setMISO(_miso);
+        SPI.setSCK(_sclk);
+	} else
+        return; // not valid pins...
 	SPI.begin();
 	if (SPI.pinIsChipSelect(_cs, _dc)) {
 		pcs_data = SPI.setCS(_cs);

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -95,7 +95,7 @@
 class ILI9341_t3 : public Print
 {
   public:
-	ILI9341_t3(uint8_t _CS, uint8_t _DC, uint8_t _RST = 255);
+	ILI9341_t3(uint8_t _CS, uint8_t _DC, uint8_t _RST = 255, uint8_t _MOSI=11, uint8_t _SCLK=13, uint8_t _MISO=12);
 	void begin(void);
 	void pushColor(uint16_t color);
 	void fillScreen(uint16_t color);
@@ -159,6 +159,7 @@ class ILI9341_t3 : public Print
   	uint8_t  _rst;
   	uint8_t _cs, _dc;
 	uint8_t pcs_data, pcs_command;
+    uint8_t _miso, _mosi, _sclk;
 
 	void setAddr(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 	  __attribute__((always_inline)) {


### PR DESCRIPTION
Thought I would see if you like the idea that the user can specify different SPI pins.  Did that in my TLC version.  Might be good when user uses music board to move clk to 14