### PR TITLE
Display windowing helpers getCursor() and setCursorWrap()

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -39,7 +39,7 @@ ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst, uint8_t mosi, uint8_
 	_width    = WIDTH;
 	_height   = HEIGHT;
 	rotation  = 0;
-	cursor_y  = cursor_x    = 0;
+	cursor_wrap_x = cursor_y  = cursor_x    = 0;
 	textsize  = 1;
 	textcolor = textbgcolor = 0xFFFF;
 	wrap      = true;
@@ -819,7 +819,7 @@ void ILI9341_t3::drawBitmap(int16_t x, int16_t y,
 size_t ILI9341_t3::write(uint8_t c) {
   if (c == '\n') {
     cursor_y += textsize*8;
-    cursor_x  = 0;
+    cursor_x  = cursor_wrap_x;
   } else if (c == '\r') {
     // skip em
   } else {
@@ -827,7 +827,7 @@ size_t ILI9341_t3::write(uint8_t c) {
     cursor_x += textsize*6;
     if (wrap && (cursor_x > (_width - textsize*6))) {
       cursor_y += textsize*8;
-      cursor_x = 0;
+      cursor_x = cursor_wrap_x;
     }
   }
   return 1;
@@ -959,6 +959,15 @@ void ILI9341_t3::drawChar(int16_t x, int16_t y, unsigned char c,
 void ILI9341_t3::setCursor(int16_t x, int16_t y) {
   cursor_x = x;
   cursor_y = y;
+}
+
+void ILI9341_t3::setCursorWrap(int16_t x) {
+  cursor_wrap_x = x;
+}
+
+void ILI9341_t3::getCursor(int16_t *x, int16_t *y) {
+  *x = cursor_x;
+  *y = cursor_y;
 }
 
 void ILI9341_t3::setTextSize(uint8_t s) {

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -131,6 +131,8 @@ class ILI9341_t3 : public Print
 	void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color);
 	void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color, uint16_t bg, uint8_t size);
 	void setCursor(int16_t x, int16_t y);
+	void setCursorWrap(int16_t x);
+	void getCursor(int16_t *x, int16_t *y);
 	void setTextColor(uint16_t c);
 	void setTextColor(uint16_t c, uint16_t bg);
 	void setTextSize(uint8_t s);
@@ -146,7 +148,7 @@ class ILI9341_t3 : public Print
  protected:
   int16_t
     _width, _height, // Display w/h as modified by current rotation
-    cursor_x, cursor_y;
+    cursor_wrap_x, cursor_x, cursor_y;
   uint16_t
     textcolor, textbgcolor;
   uint8_t


### PR DESCRIPTION
getCursor(): Since the screen x,y offset tracked in lib - the caller can benefit by finding where they ended up after a string or other write to adjust row.column location.  Allows text to reflow on screen rotate or font size change based on current (lib calculated) not hardcoded cursor() math.
Risk: Caller passing bad pointer(s) to hold known library values on return
Considered having getCursor() return current textsize value, but user tracking this can be done with care to get math right.

setCursorWrap(): Where wrapping is on it is handy to drop down lines on left edge, but windows of data can be achieved by altering the wrap position beyond 0 left edge.
Making square edged data windows allows fast 'invalidation overwrite' with fillRect() versus a full screen clear, which takes over 30% longer and causes full screen flicker. 
Risk: same as setCursor() - out of bounds value would be caught by drawChar().  Adds one int16_t to protect class data, Caller must reset as needed

Affects no low level code.
Both came in handy In my first use displaying 9DOF data for smooth efficient updates with little lib change.  16 values written with descriptive text inside 6 'fillRect()'s'

This PULL includes the getCursor changes put forth by KurtE so both not needed.