### PR TITLE
T3.4/3.5

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -402,7 +402,12 @@ static const uint8_t init_commands[] = {
 void ILI9341_t3::begin(void)
 {
     // verify SPI pins are valid;
+    #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+    if ((_mosi == 11 || _mosi == 7 || _mosi == 28) && (_miso == 12 || _miso == 8 || _miso == 39) 
+    		&& (_sclk == 13 || _sclk == 14 || _sclk == 27)) {
+	#else
     if ((_mosi == 11 || _mosi == 7) && (_miso == 12 || _miso == 8) && (_sclk == 13 || _sclk == 14)) {
+    #endif	
         SPI.setMOSI(_mosi);
         SPI.setMISO(_miso);
         SPI.setSCK(_sclk);


### PR DESCRIPTION
Allow additional pins to be used for SPI.  Note: requires fix in core as
well.
MOSI 28
MISO 39
SCLK 27
