### PR TITLE
Add more X, Y verifications to some primitives...

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -75,7 +75,8 @@ void ILI9341_t3::drawPixel(int16_t x, int16_t y, uint16_t color) {
 void ILI9341_t3::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 {
 	// Rudimentary clipping
-	if((x >= _width) || (y >= _height)) return;
+	if((x >= _width) || (x < 0) || (y >= _height)) return;
+	if(y < 0) {	h += y; y = 0; 	}
 	if((y+h-1) >= _height) h = _height-y;
 	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
 	setAddr(x, y, x, y+h-1);
@@ -90,7 +91,8 @@ void ILI9341_t3::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 void ILI9341_t3::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color)
 {
 	// Rudimentary clipping
-	if((x >= _width) || (y >= _height)) return;
+	if((x >= _width) || (y >= _height) || (y < 0)) return;
+	if(x < 0) {	w += x; x = 0; 	}
 	if((x+w-1) >= _width)  w = _width-x;
 	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
 	setAddr(x, y, x+w-1, y);
@@ -112,6 +114,8 @@ void ILI9341_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t c
 {
 	// rudimentary clipping (drawChar w/big text requires this)
 	if((x >= _width) || (y >= _height)) return;
+	if(x < 0) {	w += x; x = 0; 	}
+	if(y < 0) {	h += y; y = 0; 	}
 	if((x + w - 1) >= _width)  w = _width  - x;
 	if((y + h - 1) >= _height) h = _height - y;
 

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -275,18 +275,26 @@ class ILI9341_t3 : public Print
 	}
 	void HLine(int16_t x, int16_t y, int16_t w, uint16_t color)
 	  __attribute__((always_inline)) {
+	  	if((x >= _width) || (y >= _height) || (y < 0)) return;
+		if(x < 0) {	w += x; x = 0; 	}
+		if((x+w-1) >= _width)  w = _width-x;
+
 		setAddr(x, y, x+w-1, y);
 		writecommand_cont(ILI9341_RAMWR);
 		do { writedata16_cont(color); } while (--w > 0);
 	}
 	void VLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 	  __attribute__((always_inline)) {
+		if((x >= _width) || (x < 0) || (y >= _height)) return;
+		if(y < 0) {	h += y; y = 0; 	}
+		if((y+h-1) >= _height) h = _height-y;
 		setAddr(x, y, x, y+h-1);
 		writecommand_cont(ILI9341_RAMWR);
 		do { writedata16_cont(color); } while (--h > 0);
 	}
 	void Pixel(int16_t x, int16_t y, uint16_t color)
 	  __attribute__((always_inline)) {
+		if((x >= _width) || (x < 0) || (y >= _height) || (y < 0)) return;
 		setAddr(x, y, x, y);
 		writecommand_cont(ILI9341_RAMWR);
 		writedata16_cont(color);

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -233,7 +233,7 @@ unsigned long testFilledRects(uint16_t color1, uint16_t color2) {
                 cy = tft.height() / 2 - 1;
 
   tft.fillScreen(ILI9341_BLACK);
-  n = min(tft.width(), tft.height());
+  n = min(tft.width(), tft.height()) - 1;
   for(i=n; i>0; i-=6) {
     i2    = i / 2;
     start = micros();
@@ -324,7 +324,7 @@ unsigned long testRoundRects() {
                 cy = tft.height() / 2 - 1;
 
   tft.fillScreen(ILI9341_BLACK);
-  w     = min(tft.width(), tft.height());
+  w     = min(tft.width(), tft.height()) - 1;
   start = micros();
   for(i=0; i<w; i+=6) {
     i2 = i / 2;
@@ -342,7 +342,7 @@ unsigned long testFilledRoundRects() {
 
   tft.fillScreen(ILI9341_BLACK);
   start = micros();
-  for(i=min(tft.width(), tft.height()); i>20; i-=6) {
+  for(i=min(tft.width(), tft.height()) - 1; i>20; i-=6) {
     i2 = i / 2;
     tft.fillRoundRect(cx-i2, cy-i2, i, i, i/8, tft.color565(0, i, 0));
   }


### PR DESCRIPTION
Graphic test was calling Rectangles/Filled Rectangles and the like with
X=-1, so try to remove those cases.
(found by Defragster)

Updated graphic test to remove the issue, but in addition add some verifications for negative values in some of the graphic
primitives