### PR TITLE
Implemented Unicode support while maintaining backwards compatibility

### DIFF
--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -274,13 +274,23 @@ class ILI9341_t3 : public Print
 	void drawFontChar(unsigned int c);
 	int16_t strPixelLen(char * str);
 
- protected:
+protected:
+
+    enum UTF8_STATE {
+        UTF8_VALID,
+        UTF8_END,
+        UTF8_INVALID
+    };
+
 	int16_t _width, _height; // Display w/h as modified by current rotation
 	int16_t  cursor_x, cursor_y;
 	uint16_t textcolor, textbgcolor;
 	uint8_t textsize, rotation;
 	boolean wrap; // If set, 'wrap' text at right edge of display
 	const ILI9341_t3_font_t *font;
+    uint32_t _utf8_buffer;
+    UTF8_STATE _utf8_state;
+    uint8_t _utf8_byte_count;
 
   	uint8_t  _rst;
   	uint8_t _cs, _dc;
@@ -385,6 +395,8 @@ class ILI9341_t3 : public Print
 		writedata16_cont(color);
 	}
 	void drawFontBits(uint32_t bits, uint32_t numbits, uint32_t x, uint32_t y, uint32_t repeat);
+	uint16_t binarySearch(const uint8_t* data, const uint16_t length, const uint32_t value);
+	void nextUTF8State(const uint8_t c);
 };
 
 #ifndef swap


### PR DESCRIPTION
This PR implements Unicode support for fonts that have a Unicode codepoint table associated with them. See: https://github.com/GeoSpark/ILI9341-font-packer for Python code that generates these fonts, and examples/TakaoPGothic.c for an example.

It assumes UTF-8 encoding, but it is robust enough to ignore invalid strings of bytes, and will decode it as best it can when things get rough. I have yet to make it hang or start global thermonuclear war.

The code is backwards compatible with existing ASCII-based fonts.

The only thing I have not implemented yet is strPixelLen() which assumes an ASCII string. Modifying this would be achievable, although it may break backwards compatibility. Alternatively a second function strPixelLenUTF8() could be written to handle the more general case.