### PR TITLE
Merge ili9341_t3n updates into ili9341_t3 library.

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -20,7 +20,7 @@
 
 //Additional graphics routines by Tim Trzepacz, SoftEgg LLC added December 2015
 //(And then accidentally deleted and rewritten March 2016. Oops!)
-//Gradient support 
+//Gradient support
 //----------------
 //		fillRectVGradient	- fills area with vertical gradient
 //		fillRectHGradient	- fills area with horizontal gradient
@@ -53,7 +53,6 @@
 
 // Teensy 3.1 can only generate 30 MHz SPI when running at 120 MHz (overclock)
 // At all other speeds, SPI.beginTransaction() will use the fastest available clock
-#define SPICLOCK 30000000
 
 #define WIDTH  ILI9341_TFTWIDTH
 #define HEIGHT ILI9341_TFTHEIGHT
@@ -76,32 +75,38 @@ ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst, uint8_t mosi, uint8_
 	textcolor = textbgcolor = 0xFFFF;
 	wrap      = true;
 	font      = NULL;
+	setClipRect();
+	setOrigin();
+
+	// Added to see how much impact actually using non hardware CS pin might be
+    _cspinmask = 0;
+    _csport = NULL;
 }
 
 void ILI9341_t3::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 {
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	setAddr(x0, y0, x1, y1);
 	writecommand_last(ILI9341_RAMWR); // write to RAM
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 void ILI9341_t3::pushColor(uint16_t color)
 {
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	writedata16_last(color);
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 void ILI9341_t3::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
 	if((x < 0) ||(x >= _width) || (y < 0) || (y >= _height)) return;
 
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	setAddr(x, y, x, y);
 	writecommand_cont(ILI9341_RAMWR);
 	writedata16_last(color);
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 void ILI9341_t3::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
@@ -110,14 +115,14 @@ void ILI9341_t3::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 	if((x >= _width) || (x < 0) || (y >= _height)) return;
 	if(y < 0) {	h += y; y = 0; 	}
 	if((y+h-1) >= _height) h = _height-y;
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	setAddr(x, y, x, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	while (h-- > 1) {
 		writedata16_cont(color);
 	}
 	writedata16_last(color);
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 void ILI9341_t3::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color)
@@ -126,14 +131,14 @@ void ILI9341_t3::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color)
 	if((x >= _width) || (y >= _height) || (y < 0)) return;
 	if(x < 0) {	w += x; x = 0; 	}
 	if((x+w-1) >= _width)  w = _width-x;
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	setAddr(x, y, x+w-1, y);
 	writecommand_cont(ILI9341_RAMWR);
 	while (w-- > 1) {
 		writedata16_cont(color);
 	}
 	writedata16_last(color);
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 void ILI9341_t3::fillScreen(uint16_t color)
@@ -144,17 +149,22 @@ void ILI9341_t3::fillScreen(uint16_t color)
 // fill a rectangle
 void ILI9341_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color)
 {
-	// rudimentary clipping (drawChar w/big text requires this)
-	if((x >= _width) || (y >= _height)) return;
-	if(x < 0) {	w += x; x = 0; 	}
-	if(y < 0) {	h += y; y = 0; 	}
-	if((x + w - 1) >= _width)  w = _width  - x;
-	if((y + h - 1) >= _height) h = _height - y;
+	x+=_originx;
+	y+=_originy;
+
+	// Rectangular clipping (drawChar w/big text requires this)
+	if((x >= _displayclipx2) || (y >= _displayclipy2)) return;
+	if (((x+w) <= _displayclipx1) || ((y+h) <= _displayclipy1)) return;
+	if(x < _displayclipx1) {	w -= (_displayclipx1-x); x = _displayclipx1; 	}
+	if(y < _displayclipy1) {	h -= (_displayclipy1 - y); y = _displayclipy1; 	}
+	if((x + w - 1) >= _displayclipx2)  w = _displayclipx2  - x;
+	if((y + h - 1) >= _displayclipy2) h = _displayclipy2 - y;
+
 
 	// TODO: this can result in a very long transaction time
 	// should break this into multiple transactions, even though
 	// it'll cost more overhead, so we don't stall other SPI libs
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -163,20 +173,25 @@ void ILI9341_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t c
 		}
 		writedata16_last(color);
 		if (y > 1 && (y & 1)) {
-			SPI.endTransaction();
-			SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+			endSPITransaction();
+			beginSPITransaction();;
 		}
 	}
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 // fillRectVGradient	- fills area with vertical gradient
 void ILI9341_t3::fillRectVGradient(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color1, uint16_t color2)
 {
-	// rudimentary clipping (drawChar w/big text requires this)
-	if((x >= _width) || (y >= _height)) return;
-	if((x + w - 1) >= _width)  w = _width  - x;
-	if((y + h - 1) >= _height) h = _height - y;
+	x+=_originx;
+	y+=_originy;
+
+	// Rectangular clipping 
+	if((x >= _displayclipx2) || (y >= _displayclipy2)) return;
+	if(x < _displayclipx1) {	w -= (_displayclipx1-x); x = _displayclipx1; 	}
+	if(y < _displayclipy1) {	h -= (_displayclipy1 - y); y = _displayclipy1; 	}
+	if((x + w - 1) >= _displayclipx2)  w = _displayclipx2  - x;
+	if((y + h - 1) >= _displayclipy2) h = _displayclipy2 - y;
 	
 	int16_t r1, g1, b1, r2, g2, b2, dr, dg, db, r, g, b;
 	color565toRGB14(color1,r1,g1,b1);
@@ -187,7 +202,7 @@ void ILI9341_t3::fillRectVGradient(int16_t x, int16_t y, int16_t w, int16_t h, u
 	// TODO: this can result in a very long transaction time
 	// should break this into multiple transactions, even though
 	// it'll cost more overhead, so we don't stall other SPI libs
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -198,32 +213,37 @@ void ILI9341_t3::fillRectVGradient(int16_t x, int16_t y, int16_t w, int16_t h, u
 		}
 		writedata16_last(color);
 		if (y > 1 && (y & 1)) {
-			SPI.endTransaction();
-			SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+			endSPITransaction();
+			beginSPITransaction();;
 		}
 		r+=dr;g+=dg; b+=db;
 	}
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 // fillRectHGradient	- fills area with horizontal gradient
 void ILI9341_t3::fillRectHGradient(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color1, uint16_t color2)
 {
-	// rudimentary clipping (drawChar w/big text requires this)
-	if((x >= _width) || (y >= _height)) return;
-	if((x + w - 1) >= _width)  w = _width  - x;
-	if((y + h - 1) >= _height) h = _height - y;
+	x+=_originx;
+	y+=_originy;
+
+	// Rectangular clipping 
+	if((x >= _displayclipx2) || (y >= _displayclipy2)) return;
+	if(x < _displayclipx1) {	w -= (_displayclipx1-x); x = _displayclipx1; 	}
+	if(y < _displayclipy1) {	h -= (_displayclipy1 - y); y = _displayclipy1; 	}
+	if((x + w - 1) >= _displayclipx2)  w = _displayclipx2  - x;
+	if((y + h - 1) >= _displayclipy2) h = _displayclipy2 - y;
 	
 	int16_t r1, g1, b1, r2, g2, b2, dr, dg, db, r, g, b;
 	color565toRGB14(color1,r1,g1,b1);
 	color565toRGB14(color2,r2,g2,b2);
-	dr=(r2-r1)/h; dg=(g2-g1)/h; db=(b2-b1)/h;
+	dr=(r2-r1)/w; dg=(g2-g1)/w; db=(b2-b1)/w;
 	r=r1;g=g1;b=b1;	
 
 	// TODO: this can result in a very long transaction time
 	// should break this into multiple transactions, even though
 	// it'll cost more overhead, so we don't stall other SPI libs
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -236,12 +256,12 @@ void ILI9341_t3::fillRectHGradient(int16_t x, int16_t y, int16_t w, int16_t h, u
 		color = RGB14tocolor565(r,g,b);
 		writedata16_last(color);
 		if (y > 1 && (y & 1)) {
-			SPI.endTransaction();
-			SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+			endSPITransaction();
+			beginSPITransaction();;
 		}
 		r=r1;g=g1;b=b1;
 	}
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 // fillScreenVGradient - fills screen with vertical gradient
@@ -268,7 +288,7 @@ void ILI9341_t3::fillScreenHGradient(uint16_t color1, uint16_t color2)
 void ILI9341_t3::setRotation(uint8_t m)
 {
 	rotation = m % 4; // can't be higher than 3
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	writecommand_cont(ILI9341_MADCTL);
 	switch (rotation) {
 	case 0:
@@ -292,24 +312,27 @@ void ILI9341_t3::setRotation(uint8_t m)
 		_height = ILI9341_TFTWIDTH;
 		break;
 	}
-	SPI.endTransaction();
+	endSPITransaction();
+	setClipRect();
+	setOrigin();
+	
 	cursor_x = 0;
 	cursor_y = 0;
 }
 
 void ILI9341_t3::setScroll(uint16_t offset)
 {
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	writecommand_cont(ILI9341_VSCRSADD);
 	writedata16_last(offset);
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 void ILI9341_t3::invertDisplay(boolean i)
 {
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	writecommand_last(i ? ILI9341_INVON : ILI9341_INVOFF);
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 
@@ -350,7 +373,7 @@ uint8_t ILI9341_t3::readcommand8(uint8_t c, uint8_t index)
     uint16_t wTimeout = 0xffff;
     uint8_t r=0;
 
-    SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+    beginSPITransaction();;
     while (((KINETISK_SPI0.SR) & (15 << 12)) && (--wTimeout)) ; // wait until empty
 
     // Make sure the last frame has been sent...
@@ -394,18 +417,25 @@ uint8_t ILI9341_t3::readcommand8(uint8_t c, uint8_t index)
     while ((((KINETISK_SPI0.SR) >> 4) & 0xf) && (--wTimeout))  {
         r = KINETISK_SPI0.POPR;
     }
-    SPI.endTransaction();
+    endSPITransaction();
     return r;  // get the received byte... should check for it first...
 }
 
 
 // Read Pixel at x,y and get back 16-bit packed color
+#define READ_PIXEL_PUSH_BYTE 0x3f
 uint16_t ILI9341_t3::readPixel(int16_t x, int16_t y)
 {
 	uint8_t dummy __attribute__((unused));
 	uint8_t r,g,b;
 
-	SPI.beginTransaction(SPISettings(2000000, MSBFIRST, SPI_MODE0));
+   if (_miso == 0xff) return 0xffff;	// bail if not valid miso
+
+	beginSPITransaction(ILI9341_SPICLOCK_READ);;
+	// Update our origin. 
+	x+=_originx;
+	y+=_originy;
+
 
 	setAddr(x, y, x, y);
 	writecommand_cont(ILI9341_RAMRD); // read from RAM
@@ -415,9 +445,9 @@ uint16_t ILI9341_t3::readPixel(int16_t x, int16_t y)
 	KINETISK_SPI0.PUSHR = 0 | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_CONT;
 	waitFifoEmpty();    // wait for both queues to be empty.
 
-	KINETISK_SPI0.PUSHR = 0 | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_CONT;
-	KINETISK_SPI0.PUSHR = 0 | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_CONT;
-	KINETISK_SPI0.PUSHR = 0 | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_EOQ;
+	KINETISK_SPI0.PUSHR = READ_PIXEL_PUSH_BYTE | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_CONT;
+	KINETISK_SPI0.PUSHR = READ_PIXEL_PUSH_BYTE | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_CONT;
+	KINETISK_SPI0.PUSHR = READ_PIXEL_PUSH_BYTE | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_EOQ;
 
 	// Wait for End of Queue
 	while ((KINETISK_SPI0.SR & SPI_SR_EOQF) == 0) ;
@@ -429,18 +459,23 @@ uint16_t ILI9341_t3::readPixel(int16_t x, int16_t y)
 	g = KINETISK_SPI0.POPR;		// Read a GREEN byte of GRAM
 	b = KINETISK_SPI0.POPR;		// Read a BLUE byte of GRAM
 
-	SPI.endTransaction();
+	endSPITransaction();
 	return color565(r,g,b);
 }
 
 // Now lets see if we can read in multiple pixels
 void ILI9341_t3::readRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t *pcolors)
 {
+	// Use our Origin. 
+	x+=_originx;
+	y+=_originy;
+
 	uint8_t dummy __attribute__((unused));
 	uint8_t r,g,b;
 	uint16_t c = w * h;
 
-	SPI.beginTransaction(SPISettings(2000000, MSBFIRST, SPI_MODE0));
+   if (_miso == 0xff) return;		// bail if not valid miso
+	beginSPITransaction(ILI9341_SPICLOCK_READ);;
 
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMRD); // read from RAM
@@ -454,9 +489,9 @@ void ILI9341_t3::readRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t *
 	c *= 3; // number of bytes we will transmit to the display
 	while (c--) {
         	if (c) {
-            		KINETISK_SPI0.PUSHR = 0 | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_CONT;
+            		KINETISK_SPI0.PUSHR = READ_PIXEL_PUSH_BYTE | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_CONT;
         	} else {
-            		KINETISK_SPI0.PUSHR = 0 | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_EOQ;
+            		KINETISK_SPI0.PUSHR = READ_PIXEL_PUSH_BYTE | (pcs_data << 16) | SPI_PUSHR_CTAS(0)| SPI_PUSHR_EOQ;
 		}
 
 		// If last byte wait until all have come in...
@@ -475,22 +510,59 @@ void ILI9341_t3::readRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t *
 		// like waitFiroNotFull but does not pop our return queue
 		while ((KINETISK_SPI0.SR & (15 << 12)) > (3 << 12)) ;
 	}
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 // Now lets see if we can writemultiple pixels
 void ILI9341_t3::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors)
 {
-   	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+
+	x+=_originx;
+	y+=_originy;
+	uint16_t x_clip_left = 0;  // How many entries at start of colors to skip at start of row
+	uint16_t x_clip_right = 0;    // how many color entries to skip at end of row for clipping
+	// Rectangular clipping 
+
+	// See if the whole thing out of bounds...
+	if((x >= _displayclipx2) || (y >= _displayclipy2)) return;
+	if (((x+w) <= _displayclipx1) || ((y+h) <= _displayclipy1)) return;
+
+	// In these cases you can not do simple clipping, as we need to synchronize the colors array with the
+	// We can clip the height as when we get to the last visible we don't have to go any farther. 
+	// also maybe starting y as we will advance the color array. 
+ 	if(y < _displayclipy1) {
+ 		int dy = (_displayclipy1 - y);
+ 		h -= dy; 
+ 		pcolors += (dy*w); // Advance color array to 
+ 		y = _displayclipy1; 	
+ 	}
+
+	if((y + h - 1) >= _displayclipy2) h = _displayclipy2 - y;
+
+	// For X see how many items in color array to skip at start of row and likewise end of row 
+	if(x < _displayclipx1) {
+		x_clip_left = _displayclipx1-x; 
+		w -= x_clip_left; 
+		x = _displayclipx1; 	
+	}
+	if((x + w - 1) >= _displayclipx2) {
+		x_clip_right = w;
+		w = _displayclipx2  - x;
+		x_clip_right -= w; 
+	} 
+
+	beginSPITransaction();;
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
+		pcolors += x_clip_left;
 		for(x=w; x>1; x--) {
 			writedata16_cont(*pcolors++);
 		}
 		writedata16_last(*pcolors++);
+		pcolors += x_clip_right;
 	}
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 // writeRect8BPP - 	write 8 bit per pixel paletted bitmap
@@ -498,16 +570,57 @@ void ILI9341_t3::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uin
 //					color palette data in array at palette
 void ILI9341_t3::writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	//Serial.printf("\nWR8: %d %d %d %d %x\n", x, y, w, h, (uint32_t)pixels);
+	x+=_originx;
+	y+=_originy;
+
+	uint16_t x_clip_left = 0;  // How many entries at start of colors to skip at start of row
+	uint16_t x_clip_right = 0;    // how many color entries to skip at end of row for clipping
+	// Rectangular clipping 
+
+	// See if the whole thing out of bounds...
+	if((x >= _displayclipx2) || (y >= _displayclipy2)) return;
+	if (((x+w) <= _displayclipx1) || ((y+h) <= _displayclipy1)) return;
+
+	// In these cases you can not do simple clipping, as we need to synchronize the colors array with the
+	// We can clip the height as when we get to the last visible we don't have to go any farther. 
+	// also maybe starting y as we will advance the color array. 
+ 	if(y < _displayclipy1) {
+ 		int dy = (_displayclipy1 - y);
+ 		h -= dy; 
+ 		pixels += (dy*w); // Advance color array to 
+ 		y = _displayclipy1; 	
+ 	}
+
+	if((y + h - 1) >= _displayclipy2) h = _displayclipy2 - y;
+
+	// For X see how many items in color array to skip at start of row and likewise end of row 
+	if(x < _displayclipx1) {
+		x_clip_left = _displayclipx1-x; 
+		w -= x_clip_left; 
+		x = _displayclipx1; 	
+	}
+	if((x + w - 1) >= _displayclipx2) {
+		x_clip_right = w;
+		w = _displayclipx2  - x;
+		x_clip_right -= w; 
+	} 
+	//Serial.printf("WR8C: %d %d %d %d %x- %d %d\n", x, y, w, h, (uint32_t)pixels, x_clip_right, x_clip_left);
+   	beginSPITransaction();;
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
+		pixels += x_clip_left;
+		//Serial.printf("%x: ", (uint32_t)pixels);
 		for(x=w; x>1; x--) {
+			//Serial.print(*pixels, DEC);
 			writedata16_cont(palette[*pixels++]);
 		}
+		//Serial.println(*pixels, DEC);
 		writedata16_last(palette[*pixels++]);
+		pixels += x_clip_right;
 	}
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 // writeRect4BPP - 	write 4 bit per pixel paletted bitmap
@@ -516,18 +629,8 @@ void ILI9341_t3::writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h, const
 //					width must be at least 2 pixels
 void ILI9341_t3::writeRect4BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
-	setAddr(x, y, x+w-1, y+h-1);
-	writecommand_cont(ILI9341_RAMWR);
-	for(y=h; y>0; y--) {
-		for(x=w; x>2; x-=2) {
-			writedata16_cont(palette[((*pixels)>>4)&0xF]);
-			writedata16_cont(palette[(*pixels++)&0xF]);
-		}
-		writedata16_cont(palette[((*pixels)>>4)&0xF]);
-		writedata16_last(palette[(*pixels++)&0xF]);
-	}
-	SPI.endTransaction();
+	// Simply call through our helper
+	writeRectNBPP(x, y, w, h,  4, pixels, palette );
 }
 
 // writeRect2BPP - 	write 2 bit per pixel paletted bitmap
@@ -536,56 +639,94 @@ void ILI9341_t3::writeRect4BPP(int16_t x, int16_t y, int16_t w, int16_t h, const
 //					width must be at least 4 pixels
 void ILI9341_t3::writeRect2BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
-	setAddr(x, y, x+w-1, y+h-1);
-	writecommand_cont(ILI9341_RAMWR);
-	for(y=h; y>0; y--) {
-		for(x=w; x>4; x-=4) {
-			//unrolled loop might be faster?
-			writedata16_cont(palette[((*pixels)>>6)&0x3]);
-			writedata16_cont(palette[((*pixels)>>4)&0x3]);
-			writedata16_cont(palette[((*pixels)>>2)&0x3]);
-			writedata16_cont(palette[(*pixels++)&0x3]);
-		}
-		writedata16_cont(palette[((*pixels)>>6)&0x3]);
-		writedata16_cont(palette[((*pixels)>>4)&0x3]);
-		writedata16_cont(palette[((*pixels)>>2)&0x3]);
-		writedata16_last(palette[(*pixels++)&0x3]);
-	}
-	SPI.endTransaction();
+	// Simply call through our helper
+	writeRectNBPP(x, y, w, h,  2, pixels, palette );
+
 }
 
+///============================================================================
 // writeRect1BPP - 	write 1 bit per pixel paletted bitmap
 //					bitmap data in array at pixels, 4 bits per pixel
 //					color palette data in array at palette
 //					width must be at least 8 pixels
 void ILI9341_t3::writeRect1BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	// Simply call through our helper
+	writeRectNBPP(x, y, w, h,  1, pixels, palette );
+}
+
+
+
+///============================================================================
+// writeRectNBPP - 	write N(1, 2, 4, 8) bit per pixel paletted bitmap
+//					bitmap data in array at pixels
+//  Currently writeRect1BPP, writeRect2BPP, writeRect4BPP use this to do all of the work. 
+void ILI9341_t3::writeRectNBPP(int16_t x, int16_t y, int16_t w, int16_t h,  uint8_t bits_per_pixel, 
+		const uint8_t *pixels, const uint16_t * palette )
+{
+	//Serial.printf("\nWR8: %d %d %d %d %x\n", x, y, w, h, (uint32_t)pixels);
+	x+=_originx;
+	y+=_originy;
+	uint8_t pixels_per_byte = 8/ bits_per_pixel;
+	uint16_t count_of_bytes_per_row = (w + pixels_per_byte -1)/pixels_per_byte;		// Round up to handle non multiples
+	uint8_t row_shift_init = 8 - bits_per_pixel;				// We shift down 6 bits by default 
+	uint8_t pixel_bit_mask = (1 << bits_per_pixel) - 1; 		// get mask to use below
+	// Rectangular clipping 
+
+	// See if the whole thing out of bounds...
+	if((x >= _displayclipx2) || (y >= _displayclipy2)) return;
+	if (((x+w) <= _displayclipx1) || ((y+h) <= _displayclipy1)) return;
+
+	// In these cases you can not do simple clipping, as we need to synchronize the colors array with the
+	// We can clip the height as when we get to the last visible we don't have to go any farther. 
+	// also maybe starting y as we will advance the color array. 
+	// Again assume multiple of 8 for width
+ 	if(y < _displayclipy1) {
+ 		int dy = (_displayclipy1 - y);
+ 		h -= dy; 
+ 		pixels += dy * count_of_bytes_per_row;
+ 		y = _displayclipy1; 	
+ 	}
+
+	if((y + h - 1) >= _displayclipy2) h = _displayclipy2 - y;
+
+	// For X see how many items in color array to skip at start of row and likewise end of row 
+	if(x < _displayclipx1) {
+		uint16_t x_clip_left = _displayclipx1-x; 
+		w -= x_clip_left; 
+		x = _displayclipx1; 
+		// Now lets update pixels to the rigth offset and mask
+		uint8_t x_clip_left_bytes_incr = x_clip_left / pixels_per_byte;
+		pixels += x_clip_left_bytes_incr;
+		row_shift_init = 8 - (x_clip_left - (x_clip_left_bytes_incr * pixels_per_byte) + 1) * bits_per_pixel; 	
+	}
+
+	if((x + w - 1) >= _displayclipx2) {
+		w = _displayclipx2  - x;
+	} 
+
+	const uint8_t * pixels_row_start = pixels;  // remember our starting position offset into row
+
+
+   	beginSPITransaction();;
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
-	for(y=h; y>0; y--) {
-		for(x=w; x>8; x-=8) {
-			//unrolled loop might be faster?
-			writedata16_cont(palette[((*pixels)>>7)&0x1]);
-			writedata16_cont(palette[((*pixels)>>6)&0x1]);
-			writedata16_cont(palette[((*pixels)>>5)&0x1]);
-			writedata16_cont(palette[((*pixels)>>4)&0x1]);
-			writedata16_cont(palette[((*pixels)>>3)&0x1]);
-			writedata16_cont(palette[((*pixels)>>2)&0x1]);
-			writedata16_cont(palette[((*pixels)>>1)&0x1]);
-			writedata16_cont(palette[(*pixels++)&0x1]);
+	for (;h>0; h--) {
+		pixels = pixels_row_start;				// setup for this row
+		uint8_t pixel_shift = row_shift_init;			// Setup mask
+
+		for (int i = 0 ;i < w; i++) {
+			writedata16_cont(palette[((*pixels)>>pixel_shift) & pixel_bit_mask]);
+			if (!pixel_shift) {
+				pixel_shift = 8 - bits_per_pixel;	//setup next mask
+				pixels++;
+			} else {
+				pixel_shift -= bits_per_pixel;
+			}
 		}
-		writedata16_cont(palette[((*pixels)>>7)&0x1]);
-		writedata16_cont(palette[((*pixels)>>6)&0x1]);
-		writedata16_cont(palette[((*pixels)>>5)&0x1]);
-		writedata16_cont(palette[((*pixels)>>4)&0x1]);
-		writedata16_cont(palette[((*pixels)>>3)&0x1]);
-		writedata16_cont(palette[((*pixels)>>2)&0x1]);
-		writedata16_cont(palette[((*pixels)>>1)&0x1]);
-		writedata16_last(palette[(*pixels++)&0x1]);
+		pixels_row_start += count_of_bytes_per_row;
 	}
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 
@@ -619,24 +760,49 @@ void ILI9341_t3::begin(void)
 {
     // verify SPI pins are valid;
     #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-    if ((_mosi == 11 || _mosi == 7 || _mosi == 28) && (_miso == 12 || _miso == 8 || _miso == 39) 
-    		&& (_sclk == 13 || _sclk == 14 || _sclk == 27)) {
+    // Allow to work with mimimum of MOSI and SCK
+    if ((_mosi == 255 || _mosi == 11 || _mosi == 7 || _mosi == 28)  && (_sclk == 255 || _sclk == 13 || _sclk == 14 || _sclk == 27)) 
 	#else
-    if ((_mosi == 11 || _mosi == 7) && (_miso == 12 || _miso == 8) && (_sclk == 13 || _sclk == 14)) {
+    if ((_mosi == 255 || _mosi == 11 || _mosi == 7) && (_sclk == 255 || _sclk == 13 || _sclk == 14)) 
     #endif	
-        SPI.setMOSI(_mosi);
-        SPI.setMISO(_miso);
-        SPI.setSCK(_sclk);
-	} else
+    {
+        
+		if (_mosi != 255) SPI.setMOSI(_mosi);
+        if (_sclk != 255) SPI.setSCK(_sclk);
+
+        // Now see if valid MISO
+	    #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+	    if (_miso == 12 || _miso == 8 || _miso == 39)
+		#else
+	    if (_miso == 12 || _miso == 8)
+	    #endif
+		{	
+        	SPI.setMISO(_miso);
+    	} else {
+			_miso = 0xff;	// set miso to 255 as flag it is bad
+		}
+	} else {
         return; // not valid pins...
+	}
+
 	SPI.begin();
 	if (SPI.pinIsChipSelect(_cs, _dc)) {
 		pcs_data = SPI.setCS(_cs);
 		pcs_command = pcs_data | SPI.setCS(_dc);
 	} else {
-		pcs_data = 0;
-		pcs_command = 0;
-		return;
+		// See if at least DC is on chipselect pin, if so try to limp along...
+		if (SPI.pinIsChipSelect(_dc)) {
+			pcs_data = 0;
+			pcs_command = pcs_data | SPI.setCS(_dc);
+			pinMode(_cs, OUTPUT);
+			_csport    = portOutputRegister(digitalPinToPort(_cs));
+			_cspinmask = digitalPinToBitMask(_cs);
+
+
+		} else {
+			pcs_data = 0;
+
+		}
 	}
 	// toggle RST low to reset
 	if (_rst < 255) {
@@ -660,7 +826,7 @@ void ILI9341_t3::begin(void)
 	x = readcommand8(ILI9341_RDSELFDIAG);
 	Serial.print("\nSelf Diagnostic: 0x"); Serial.println(x, HEX);
 	*/
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	const uint8_t *addr = init_commands;
 	while (1) {
 		uint8_t count = *addr++;
@@ -671,12 +837,12 @@ void ILI9341_t3::begin(void)
 		}
 	}
 	writecommand_last(ILI9341_SLPOUT);    // Exit Sleep
-	SPI.endTransaction();
+	endSPITransaction();
 
 	delay(120); 		
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	writecommand_last(ILI9341_DISPON);    // Display on
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 
@@ -872,7 +1038,7 @@ void ILI9341_t3::drawLine(int16_t x0, int16_t y0,
 		ystep = -1;
 	}
 
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	int16_t xbegin = x0;
 	if (steep) {
 		for (; x0<=x1; x0++) {
@@ -913,19 +1079,19 @@ void ILI9341_t3::drawLine(int16_t x0, int16_t y0,
 		}
 	}
 	writecommand_last(ILI9341_NOP);
-	SPI.endTransaction();
+	endSPITransaction();
 }
 
 // Draw a rectangle
 void ILI9341_t3::drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color)
 {
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	HLine(x, y, w, color);
 	HLine(x, y+h-1, w, color);
 	VLine(x, y, h, color);
 	VLine(x+w-1, y, h, color);
-	writecommand_last(ILI9341_NOP);
-	SPI.endTransaction();
+
+
 }
 
 // Draw a rounded rectangle
@@ -1177,32 +1343,70 @@ void ILI9341_t3::drawChar(int16_t x, int16_t y, unsigned char c,
 		}
 	} else {
 		// This solid background approach is about 5 time faster
-		SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
-		setAddr(x, y, x + 6 * size - 1, y + 8 * size - 1);
-		writecommand_cont(ILI9341_RAMWR);
+		uint8_t xc, yc;
 		uint8_t xr, yr;
 		uint8_t mask = 0x01;
 		uint16_t color;
-		for (y=0; y < 8; y++) {
-			for (yr=0; yr < size; yr++) {
-				for (x=0; x < 5; x++) {
-					if (glcdfont[c * 5 + x] & mask) {
-						color = fgcolor;
-					} else {
-						color = bgcolor;
+
+		// We need to offset by the origin.
+		x+=_originx;
+		y+=_originy;
+		int16_t x_char_start = x;  // remember our X where we start outputting...
+
+		if((x >= _displayclipx2)            || // Clip right
+			 (y >= _displayclipy2)           || // Clip bottom
+			 ((x + 6 * size - 1) < _displayclipx1) || // Clip left  TODO: this is not correct
+			 ((y + 8 * size - 1) < _displayclipy1))   // Clip top   TODO: this is not correct
+			return;
+
+
+		{
+			// need to build actual pixel rectangle we will output into.
+			int16_t y_char_top = y;	// remember the y
+			int16_t w =  6 * size;
+			int16_t h = 8 * size;
+
+			if(x < _displayclipx1) {	w -= (_displayclipx1-x); x = _displayclipx1; 	}
+			if((x + w - 1) >= _displayclipx2)  w = _displayclipx2  - x;
+			if(y < _displayclipy1) {	h -= (_displayclipy1 - y); y = _displayclipy1; 	}
+			if((y + h - 1) >= _displayclipy2) h = _displayclipy2 - y;
+
+			beginSPITransaction();;
+			setAddr(x, y, x + w -1, y + h - 1);
+
+			y = y_char_top;	// restore the actual y.
+			writecommand_cont(ILI9341_RAMWR);
+			for (yc=0; (yc < 8) && (y < _displayclipy2); yc++) {
+				for (yr=0; (yr < size) && (y < _displayclipy2); yr++) {
+					x = x_char_start; 		// get our first x position...
+					if (y >= _displayclipy1) {
+						for (xc=0; xc < 5; xc++) {
+							if (glcdfont[c * 5 + xc] & mask) {
+								color = fgcolor;
+							} else {
+								color = bgcolor;
+							}
+							for (xr=0; xr < size; xr++) {
+								if ((x >= _displayclipx1) && (x < _displayclipx2)) {
+									writedata16_cont(color);
+								}
+								x++;
+							}
+						}
+						for (xr=0; xr < size; xr++) {
+							if ((x >= _displayclipx1) && (x < _displayclipx2)) {
+								writedata16_cont(bgcolor);
+							}
+							x++;
+						}
 					}
-					for (xr=0; xr < size; xr++) {
-						writedata16_cont(color);
-					}
+					y++;
 				}
-				for (xr=0; xr < size; xr++) {
-					writedata16_cont(bgcolor);
-				}
+				mask = mask << 1;
 			}
-			mask = mask << 1;
+			writecommand_last(ILI9341_NOP);
+			endSPITransaction();
 		}
-		writecommand_last(ILI9341_NOP);
-		SPI.endTransaction();
 	}
 }
 
@@ -1271,6 +1475,7 @@ void ILI9341_t3::drawFontChar(unsigned int c)
 	uint32_t height = fetchbits_unsigned(data, bitoffset, font->bits_height);
 	bitoffset += font->bits_height;
 	//Serial.printf("  size =   %d,%d\n", width, height);
+	//Serial.printf("  line space = %d\n", font->line_space);
 
 	int32_t xoffset = fetchbits_signed(data, bitoffset, font->bits_xoffset);
 	bitoffset += font->bits_xoffset;
@@ -1284,7 +1489,7 @@ void ILI9341_t3::drawFontChar(unsigned int c)
 
 	//Serial.printf("  cursor = %d,%d\n", cursor_x, cursor_y);
 
-	// horizontally, we draw every pixel, or none at all
+	 //horizontally, we draw every pixel, or none at all
 	if (cursor_x < 0) cursor_x = 0;
 	int32_t origin_x = cursor_x + xoffset;
 	if (origin_x < 0) {
@@ -1302,7 +1507,6 @@ void ILI9341_t3::drawFontChar(unsigned int c)
 		cursor_y += font->line_space;
 	}
 	if (cursor_y >= _height) return;
-	cursor_x += delta;
 
 	// vertically, the top and/or bottom can be clipped
 	int32_t origin_y = cursor_y + font->cap_height - height - yoffset;
@@ -1311,44 +1515,180 @@ void ILI9341_t3::drawFontChar(unsigned int c)
 	// TODO: compute top skip and number of lines
 	int32_t linecount = height;
 	//uint32_t loopcount = 0;
-	uint32_t y = origin_y;
-	while (linecount) {
-		//Serial.printf("    linecount = %d\n", linecount);
-		uint32_t b = fetchbit(data, bitoffset++);
-		if (b == 0) {
-			//Serial.println("    single line");
+	int32_t y = origin_y;
+	bool opaque = (textbgcolor != textcolor);
+
+
+	// Going to try a fast Opaque method which works similar to drawChar, which is near the speed of writerect
+	if (!opaque) {
+		while (linecount > 0) {
+			//Serial.printf("    linecount = %d\n", linecount);
+			uint32_t n = 1;
+			if (fetchbit(data, bitoffset++) != 0) {
+				n = fetchbits_unsigned(data, bitoffset, 3) + 2;
+				bitoffset += 3;
+			}
 			uint32_t x = 0;
 			do {
-				uint32_t xsize = width - x;
+				int32_t xsize = width - x;
 				if (xsize > 32) xsize = 32;
 				uint32_t bits = fetchbits_unsigned(data, bitoffset, xsize);
-				drawFontBits(bits, xsize, origin_x + x, y, 1);
+				//Serial.printf("    multi line %d %d %x\n", n, x, bits);
+				drawFontBits(opaque, bits, xsize, origin_x + x, y, n);
 				bitoffset += xsize;
 				x += xsize;
 			} while (x < width);
-			y++;
-			linecount--;
-		} else {
-			uint32_t n = fetchbits_unsigned(data, bitoffset, 3) + 2;
-			bitoffset += 3;
-			uint32_t x = 0;
-			do {
-				uint32_t xsize = width - x;
-				if (xsize > 32) xsize = 32;
-				//Serial.printf("    multi line %d\n", n);
-				uint32_t bits = fetchbits_unsigned(data, bitoffset, xsize);
-				drawFontBits(bits, xsize, origin_x + x, y, n);
-				bitoffset += xsize;
-				x += xsize;
-			} while (x < width);
+
+
 			y += n;
 			linecount -= n;
+			//if (++loopcount > 100) {
+				//Serial.println("     abort draw loop");
+				//break;
+			//}
 		}
-		//if (++loopcount > 100) {
-			//Serial.println("     abort draw loop");
-			//break;
-		//}
+	} else {
+		// Now opaque mode... 
+		// Now write out background color for the number of rows above the above the character
+		// figure out bounding rectangle... 
+		// In this mode we need to update to use the offset and bounding rectangles as we are doing it it direct.
+		// also update the Origin 
+		int cursor_x_origin = cursor_x + _originx;
+		int cursor_y_origin = cursor_y + _originy;
+		origin_x += _originx;
+		origin_y += _originy;
+
+
+
+		int start_x = (origin_x < cursor_x_origin) ? origin_x : cursor_x_origin; 	
+		if (start_x < 0) start_x = 0;
+		
+		int start_y = (origin_y < cursor_y_origin) ? origin_y : cursor_y_origin; 
+		if (start_y < 0) start_y = 0;
+		int end_x = cursor_x_origin + delta; 
+		if ((origin_x + (int)width) > end_x)
+			end_x = origin_x + (int)width;
+		if (end_x >= _displayclipx2)  end_x = _displayclipx2;	
+		int end_y = cursor_y_origin + font->line_space; 
+		if ((origin_y + (int)height) > end_y)
+			end_y = origin_y + (int)height;
+		if (end_y >= _displayclipy2) end_y = _displayclipy2;	
+		end_x--;	// setup to last one we draw
+		end_y--;
+		int start_x_min = (start_x >= _displayclipx1) ? start_x : _displayclipx1;
+		int start_y_min = (start_y >= _displayclipy1) ? start_y : _displayclipy1;
+
+		// See if anything is in the display area.
+		if((end_x < _displayclipx1) ||(start_x >= _displayclipx2) || (end_y < _displayclipy1) || (start_y >= _displayclipy2)) {
+			cursor_x += delta;	// could use goto or another indent level...
+		 	return;
+		}
+/*
+		Serial.printf("drawFontChar(%c) %d\n", c, c);
+		Serial.printf("  size =   %d,%d\n", width, height);
+		Serial.printf("  line space = %d\n", font->line_space);
+		Serial.printf("  offset = %d,%d\n", xoffset, yoffset);
+		Serial.printf("  delta =  %d\n", delta);
+		Serial.printf("  cursor = %d,%d\n", cursor_x, cursor_y);
+		Serial.printf("  origin = %d,%d\n", origin_x, origin_y);
+
+		Serial.printf("  Bounding: (%d, %d)-(%d, %d)\n", start_x, start_y, end_x, end_y);
+
+*/
+
+		{
+			beginSPITransaction();;
+			//Serial.printf("SetAddr %d %d %d %d\n", start_x_min, start_y_min, end_x, end_y);
+			// output rectangle we are updating... We have already clipped end_x/y, but not yet start_x/y
+			setAddr( start_x_min, start_y_min, end_x, end_y);
+			writecommand_cont(ILI9341_RAMWR);
+			int screen_y = start_y_min;
+			int screen_x;
+			while (screen_y < origin_y) {
+				for (screen_x = start_x_min; screen_x <= end_x; screen_x++) {
+					writedata16_cont(textbgcolor);
+				}
+				screen_y++;
+			}
+
+			// Now lets process each of the data lines. 
+			screen_y = origin_y;
+			while (linecount > 0) {
+				//Serial.printf("    linecount = %d\n", linecount);
+				uint32_t b = fetchbit(data, bitoffset++);
+				uint32_t n;
+				if (b == 0) {
+					//Serial.println("    Single");
+					n = 1;
+				} else {
+					//Serial.println("    Multi");
+					n = fetchbits_unsigned(data, bitoffset, 3) + 2;
+					bitoffset += 3;
+				}
+				uint32_t bitoffset_row_start = bitoffset;
+				while (n--) {
+					// do some clipping here. 
+					bitoffset = bitoffset_row_start;	// we will work through these bits maybe multiple times
+					// We need to handle case where some of the bits may not be visible, but we still need to
+					// read through them
+					//Serial.printf("y:%d  %d %d %d %d\n", screen_y, start_x, origin_x, _displayclipx1, _displayclipx2);
+					if ((screen_y >= _displayclipy1) && (screen_y < _displayclipy2)) {
+						for (screen_x = start_x; screen_x < origin_x; screen_x++) {
+							if ((screen_x >= _displayclipx1) && (screen_x < _displayclipx2)) {
+								//Serial.write('-');
+								writedata16_cont(textbgcolor);
+							}
+						}
+					}	
+					uint32_t x = 0;
+					screen_x = origin_x;
+					do {
+						uint32_t xsize = width - x;
+						if (xsize > 32) xsize = 32;
+						uint32_t bits = fetchbits_unsigned(data, bitoffset, xsize);
+						uint32_t bit_mask = 1 << (xsize-1);
+						//Serial.printf("     %d %d %x %x - ", x, xsize, bits, bit_mask);
+						if ((screen_y >= _displayclipy1) && (screen_y < _displayclipy2)) {
+							while (bit_mask) {
+								if ((screen_x >= _displayclipx1) && (screen_x < _displayclipx2)) {
+									writedata16_cont((bits & bit_mask) ? textcolor : textbgcolor);
+									//Serial.write((bits & bit_mask) ? '*' : '.');
+								}
+								bit_mask = bit_mask >> 1;
+								screen_x++ ; // Current actual screen X
+							}
+							//Serial.println();
+							bitoffset += xsize;
+						}
+						x += xsize;
+					} while (x < width) ;
+					if ((screen_y >= _displayclipy1) && (screen_y < _displayclipy2)) {
+						// output bg color and right hand side
+						while (screen_x++ <= end_x) {
+							writedata16_cont(textbgcolor);
+							//Serial.write('+');
+						}
+						//Serial.println();
+					}
+		 			screen_y++;
+					linecount--;
+				}
+			}
+
+			// clear below character - note reusing xcreen_x for this
+			screen_x = (end_y + 1 - screen_y) * (end_x + 1 - start_x_min); // How many bytes we need to still output
+			//Serial.printf("Clear Below: %d\n", screen_x);
+			while (screen_x-- > 1) {
+				writedata16_cont(textbgcolor);
+			}
+			writedata16_last(textbgcolor);
+			endSPITransaction();
+		}
+
 	}
+	// Increment to setup for the next character.
+	cursor_x += delta;
+
 }
 
 //strPixelLen			- gets pixel length of given ASCII string
@@ -1428,76 +1768,51 @@ int16_t ILI9341_t3::strPixelLen(char * str)
 	return( maxlen );
 }
 
-void ILI9341_t3::drawFontBits(uint32_t bits, uint32_t numbits, uint32_t x, uint32_t y, uint32_t repeat)
+void ILI9341_t3::drawFontBits(bool opaque, uint32_t bits, uint32_t numbits, int32_t x, int32_t y, uint32_t repeat)
 {
-#if 0			
-	// TODO: replace this *slow* code with something fast...
-	//Serial.printf("      %d bits at %d,%d: %X\n", numbits, x, y, bits);
-	if (bits == 0) return;
-	do {
-		uint32_t x1 = x;
+	if (bits == 0) {
+		if (opaque) {
+			fillRect(x, y, numbits, repeat, textbgcolor);
+		}
+	} else {
+		int32_t x1 = x;
 		uint32_t n = numbits;
+		int w;
+		int bgw;
+
+		w = 0;
+		bgw = 0;
+
 		do {
 			n--;
 			if (bits & (1 << n)) {
-				drawPixel(x1, y, textcolor);
-				//Serial.printf("        pixel at %d,%d\n", x1, y);
-			}
-			x1++;
-		} while (n > 0);
-		y++;
-		repeat--;
-	} while (repeat);
-#endif
-#if 1
-	if (bits == 0) return;
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
-	int w = 0;
-	do {
-		uint32_t x1 = x;
-		uint32_t n = numbits;		
-		
-		writecommand_cont(ILI9341_PASET); // Row addr set
-		writedata16_cont(y);   // YSTART
-		writedata16_cont(y);   // YEND	
-		
-		do {
-			n--;
-			if (bits & (1 << n)) {
-				w++;
-			}
-			else if (w > 0) {
-				// "drawFastHLine(x1 - w, y, w, textcolor)"
-				writecommand_cont(ILI9341_CASET); // Column addr set
-				writedata16_cont(x1 - w);   // XSTART
-				writedata16_cont(x1);   // XEND					
-				writecommand_cont(ILI9341_RAMWR);
-				while (w-- > 1) { // draw line
-					writedata16_cont(textcolor);
+				if (bgw>0) {
+					if (opaque) {
+						fillRect(x1 - bgw, y, bgw, repeat, textbgcolor);
+					}
+					bgw=0;
 				}
-				writedata16_last(textcolor);
+				w++;
+			} else {
+				if (w>0) {
+					fillRect(x1 - w, y, w, repeat, textcolor);
+					w = 0;
+				}
+				bgw++;
 			}
-						
 			x1++;
 		} while (n > 0);
 
 		if (w > 0) {
-				// "drawFastHLine(x1 - w, y, w, textcolor)"
-				writecommand_cont(ILI9341_CASET); // Column addr set
-				writedata16_cont(x1 - w);   // XSTART
-				writedata16_cont(x1);   // XEND
-				writecommand_cont(ILI9341_RAMWR);				
-				while (w-- > 1) { //draw line
-					writedata16_cont(textcolor);
-				}
-				writedata16_last(textcolor);
+			fillRect(x1 - w, y, w, repeat, textcolor);
 		}
-		
-		y++;
-		repeat--;
-	} while (repeat);
-	SPI.endTransaction();
-#endif	
+
+		if (bgw > 0) {
+			if (opaque) {
+				fillRect(x1 - bgw, y, bgw, repeat, textbgcolor);
+			}
+		}
+	}
 }
 
 void ILI9341_t3::setCursor(int16_t x, int16_t y) {
@@ -1547,15 +1862,15 @@ uint8_t ILI9341_t3::getRotation(void) {
 }
 
 void ILI9341_t3::sleep(bool enable) {
-	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+	beginSPITransaction();;
 	if (enable) {
 		writecommand_cont(ILI9341_DISPOFF);		
 		writecommand_last(ILI9341_SLPIN);	
-		  SPI.endTransaction();
+		  endSPITransaction();
 	} else {
 		writecommand_cont(ILI9341_DISPON);
 		writecommand_last(ILI9341_SLPOUT);
-		SPI.endTransaction();
+		endSPITransaction();
 		delay(5);
 	}
 }


### PR DESCRIPTION
The changes include things like:
Allow you to setup drawing offsets.
Allow you to setup clipping rectangle
Opaque font character drawing.
Fix for readRect?  Why mine needs 0x3f instead of 0x00?  not sure...

Also More support for partial pins...

Works with only one hardware CS pin must be used for DC.

Also if MOSI and SCK are valid but MISO is not, it still runs, but input
functions will fail.

Also if any of the pins are 0xff or 255, they will simply default to the
current defined SPI pins.

Note: It appears to grow the library about 2K, at least on T3.6 compile of graphic test went from 49568 to 51760.

Performance appears pretty close:
Master: 
ILI9341 Test!
Display Power Mode: 0xCE
MADCTL Mode: 0x24
Pixel Format: 0x2
Image Format: 0x0
Self Diagnostic: 0xE0
Benchmark                Time (microseconds)
Screen fill              224745
Text                     11343
Lines                    58362
Horiz/Vert Lines         18380
Rectangles (outline)     11682
Rectangles (filled)      461662
Circles (filled)         69356
Circles (outline)        53750
Triangles (outline)      14108
Triangles (filled)       153772
Rounded rects (outline)  24568
Rounded rects (filled)   504122
Done!

With these changes: 
ILI9341 Test!
Display Power Mode: 0xCE
MADCTL Mode: 0x24
Pixel Format: 0x2
Image Format: 0x0
Self Diagnostic: 0x0
Benchmark                Time (microseconds)
Screen fill              224829
Text                     11437
Lines                    58381
Horiz/Vert Lines         18387
Rectangles (outline)     11632
Rectangles (filled)      461877
Circles (filled)         69604
Circles (outline)        53872
Triangles (outline)      14118
Triangles (filled)       153938
Rounded rects (outline)  24619
Rounded rects (filled)   504348
Done!