### PR TITLE
Implemented the vertical scrolling definition command.

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -305,6 +305,16 @@ void ILI9341_t3::setScroll(uint16_t offset)
 	SPI.endTransaction();
 }
 
+void ILI9341_t3::setScrollingDefinition(uint16_t tfa, uint16_t vsa, uint16_t bfa)
+{
+  SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));
+  writecommand_cont(ILI9341_VSCRDEF);
+  writedata16_cont(tfa);
+  writedata16_cont(vsa);
+  writedata16_last(bfa);
+  SPI.endTransaction();
+}
+
 void ILI9341_t3::invertDisplay(boolean i)
 {
 	SPI.beginTransaction(SPISettings(SPICLOCK, MSBFIRST, SPI_MODE0));

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -90,6 +90,7 @@
 #define ILI9341_RAMRD   0x2E
 
 #define ILI9341_PTLAR    0x30
+#define ILI9341_VSCRDEF  0x33
 #define ILI9341_MADCTL   0x36
 #define ILI9341_VSCRSADD 0x37
 #define ILI9341_PIXFMT   0x3A
@@ -188,6 +189,7 @@ class ILI9341_t3 : public Print
 
 	void setRotation(uint8_t r);
 	void setScroll(uint16_t offset);
+	void setScrollingDefinition(uint16_t tfa, uint16_t vsa, uint16_t bfa);
 	void invertDisplay(boolean i);
 	void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
 	// Pass 8-bit (each) R,G,B, get back 16-bit packed color


### PR DESCRIPTION
This pull request adds the vertical scrolling definition command for the ILI9341 (see section 8.2.26 of the datasheet), which can be used in conjunction with the vertical scroll command already implemented in the library (setScroll). The vertical scrolling definition command modifies the scroll feature behavior, allowing for certain rows to be scrolled and certain rows to stay in place.