### PR TITLE
rmv deprecated warning

### DIFF
--- a/extras/ttf_to_ili9341.pl
+++ b/extras/ttf_to_ili9341.pl
@@ -28,7 +28,7 @@ print H "#endif\n\n";
 while (<C>) {
 	chop;
 	next unless /^const/;
-	s/ = {$//;
+	s/ = \{$//;
 	print H "extern $_;\n";
 	#print "$_\n";
 }


### PR DESCRIPTION
"Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/ = { <-- HERE $/ at ../ttf_to_ili9341.pl line 31."