### PR TITLE
Add string measurement APIs

### DIFF
--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -282,6 +282,12 @@ class ILI9341_t3 : public Print
 	void setFont(const ILI9341_t3_font_t &f) { font = &f; }
 	void setFontAdafruit(void) { font = NULL; }
 	void drawFontChar(unsigned int c);
+	void measureChar(uint8_t c, uint16_t* w, uint16_t* h);
+	uint16_t fontCapHeight() { return (font) ? font->cap_height : textsize * 8; }
+	uint16_t fontLineSpace() { return (font) ? font->line_space : textsize * 8; }
+	uint16_t fontGap() { return (font) ? font->line_space - font->cap_height : 0; };
+	uint16_t measureTextWidth(const char* text, int chars = 0);
+	uint16_t measureTextHeight(const char* text, int chars = 0);
 	int16_t strPixelLen(char * str);
 
  protected:


### PR DESCRIPTION
This PR adds the minimum necessary changes to support the reading of text string dimensions in the current font mode. These APIs are essential in order to enable other libraries to offer horizontal / vertical text justification with ILI9341_t3.

### Details
- Add `measureTextWidth()`, `measureTextHeight()`
- Largely based on the work by @blackketter in his ILI9341_t3 [fork](https://github.com/blackketter/ILI9341_t3), with additional fixes for font height metrics in `setFontAdafruit()` mode

### Testing
- Confirmed full text justification works correctly after integrating into the [GUIslice](https://github.com/ImpulseAdventure/GUIslice) GUI framework library (using both the default **Adafruit-GFX** font as well as the **ILI9341_t3** fonts).
- Confirmed existing ILI9341_t3 examples such as graphicstest & DemoSauce work correctly

Thanks