### PR TITLE
Added ability to set SPI clock speed

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -82,7 +82,7 @@ ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst, uint8_t mosi, uint8_
 
 void ILI9341_t3::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 {
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	setAddr(x0, y0, x1, y1);
 	writecommand_last(ILI9341_RAMWR); // write to RAM
 	endSPITransaction();
@@ -90,7 +90,7 @@ void ILI9341_t3::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y
 
 void ILI9341_t3::pushColor(uint16_t color)
 {
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	writedata16_last(color);
 	endSPITransaction();
 }
@@ -99,7 +99,7 @@ void ILI9341_t3::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
 	if((x < 0) ||(x >= _width) || (y < 0) || (y >= _height)) return;
 
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	setAddr(x, y, x, y);
 	writecommand_cont(ILI9341_RAMWR);
 	writedata16_last(color);
@@ -112,7 +112,7 @@ void ILI9341_t3::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 	if((x >= _width) || (x < 0) || (y >= _height)) return;
 	if(y < 0) {	h += y; y = 0; 	}
 	if((y+h-1) >= _height) h = _height-y;
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	setAddr(x, y, x, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	while (h-- > 1) {
@@ -128,7 +128,7 @@ void ILI9341_t3::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color)
 	if((x >= _width) || (y >= _height) || (y < 0)) return;
 	if(x < 0) {	w += x; x = 0; 	}
 	if((x+w-1) >= _width)  w = _width-x;
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y);
 	writecommand_cont(ILI9341_RAMWR);
 	while (w-- > 1) {
@@ -156,7 +156,7 @@ void ILI9341_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t c
 	// TODO: this can result in a very long transaction time
 	// should break this into multiple transactions, even though
 	// it'll cost more overhead, so we don't stall other SPI libs
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -166,7 +166,7 @@ void ILI9341_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t c
 		writedata16_last(color);
 		if (y > 1 && (y & 1)) {
 			endSPITransaction();
-			beginSPITransaction();
+			beginSPITransaction(_clock);
 		}
 	}
 	endSPITransaction();
@@ -189,7 +189,7 @@ void ILI9341_t3::fillRectVGradient(int16_t x, int16_t y, int16_t w, int16_t h, u
 	// TODO: this can result in a very long transaction time
 	// should break this into multiple transactions, even though
 	// it'll cost more overhead, so we don't stall other SPI libs
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -201,7 +201,7 @@ void ILI9341_t3::fillRectVGradient(int16_t x, int16_t y, int16_t w, int16_t h, u
 		writedata16_last(color);
 		if (y > 1 && (y & 1)) {
 			endSPITransaction();
-			beginSPITransaction();
+			beginSPITransaction(_clock);
 		}
 		r+=dr;g+=dg; b+=db;
 	}
@@ -225,7 +225,7 @@ void ILI9341_t3::fillRectHGradient(int16_t x, int16_t y, int16_t w, int16_t h, u
 	// TODO: this can result in a very long transaction time
 	// should break this into multiple transactions, even though
 	// it'll cost more overhead, so we don't stall other SPI libs
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -239,7 +239,7 @@ void ILI9341_t3::fillRectHGradient(int16_t x, int16_t y, int16_t w, int16_t h, u
 		writedata16_last(color);
 		if (y > 1 && (y & 1)) {
 			endSPITransaction();
-			beginSPITransaction();
+			beginSPITransaction(_clock);
 		}
 		r=r1;g=g1;b=b1;
 	}
@@ -270,7 +270,7 @@ void ILI9341_t3::fillScreenHGradient(uint16_t color1, uint16_t color2)
 void ILI9341_t3::setRotation(uint8_t m)
 {
 	rotation = m % 4; // can't be higher than 3
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	writecommand_cont(ILI9341_MADCTL);
 	switch (rotation) {
 	case 0:
@@ -301,7 +301,7 @@ void ILI9341_t3::setRotation(uint8_t m)
 
 void ILI9341_t3::setScroll(uint16_t offset)
 {
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	writecommand_cont(ILI9341_VSCRSADD);
 	writedata16_last(offset);
 	endSPITransaction();
@@ -309,7 +309,7 @@ void ILI9341_t3::setScroll(uint16_t offset)
 
 void ILI9341_t3::invertDisplay(boolean i)
 {
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	writecommand_last(i ? ILI9341_INVON : ILI9341_INVOFF);
 	endSPITransaction();
 }
@@ -356,7 +356,7 @@ uint8_t ILI9341_t3::readcommand8(uint8_t c, uint8_t index)
     uint16_t wTimeout = 0xffff;
     uint8_t r=0;
 
-    beginSPITransaction();
+    beginSPITransaction(_clock);
     while (((KINETISK_SPI0.SR) & (15 << 12)) && (--wTimeout)) ; // wait until empty
 
     // Make sure the last frame has been sent...
@@ -437,7 +437,7 @@ uint8_t ILI9341_t3::readcommand8(uint8_t c, uint8_t index)
     endSPITransaction();
     return r;  // get the received byte... should check for it first...
 #else
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	writecommand_cont(0xD9);
 	writedata8_cont(0x10 + index);
 
@@ -592,7 +592,7 @@ void ILI9341_t3::readRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t *
 // Now lets see if we can writemultiple pixels
 void ILI9341_t3::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors)
 {
-   	beginSPITransaction();
+   	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -609,7 +609,7 @@ void ILI9341_t3::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uin
 //					color palette data in array at palette
 void ILI9341_t3::writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	beginSPITransaction();
+   	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -627,7 +627,7 @@ void ILI9341_t3::writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h, const
 //					width must be at least 2 pixels
 void ILI9341_t3::writeRect4BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	beginSPITransaction();
+   	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -647,7 +647,7 @@ void ILI9341_t3::writeRect4BPP(int16_t x, int16_t y, int16_t w, int16_t h, const
 //					width must be at least 4 pixels
 void ILI9341_t3::writeRect2BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	beginSPITransaction();
+   	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -672,7 +672,7 @@ void ILI9341_t3::writeRect2BPP(int16_t x, int16_t y, int16_t w, int16_t h, const
 //					width must be at least 8 pixels
 void ILI9341_t3::writeRect1BPP(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t *pixels, const uint16_t * palette )
 {
-   	beginSPITransaction();
+   	beginSPITransaction(_clock);
 	setAddr(x, y, x+w-1, y+h-1);
 	writecommand_cont(ILI9341_RAMWR);
 	for(y=h; y>0; y--) {
@@ -826,7 +826,7 @@ void ILI9341_t3::begin(void)
 	x = readcommand8(ILI9341_RDSELFDIAG);
 	Serial.print("\nSelf Diagnostic: 0x"); Serial.println(x, HEX);
 	*/
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	const uint8_t *addr = init_commands;
 	while (1) {
 		uint8_t count = *addr++;
@@ -840,7 +840,7 @@ void ILI9341_t3::begin(void)
 	endSPITransaction();
 
 	delay(120); 		
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	writecommand_last(ILI9341_DISPON);    // Display on
 	endSPITransaction();
 }
@@ -1038,7 +1038,7 @@ void ILI9341_t3::drawLine(int16_t x0, int16_t y0,
 		ystep = -1;
 	}
 
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	int16_t xbegin = x0;
 	if (steep) {
 		for (; x0<=x1; x0++) {
@@ -1085,7 +1085,7 @@ void ILI9341_t3::drawLine(int16_t x0, int16_t y0,
 // Draw a rectangle
 void ILI9341_t3::drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color)
 {
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	HLine(x, y, w, color);
 	HLine(x, y+h-1, w, color);
 	VLine(x, y, h, color);
@@ -1284,7 +1284,7 @@ void ILI9341_t3::drawChar(int16_t x, int16_t y, unsigned char c,
 		} // for y
 	} else {
 		// This solid background approach is about 5 time faster
-		beginSPITransaction();
+		beginSPITransaction(_clock);
 		setAddr(x, y, x + 6 * size - 1, y + 8 * size - 1);
 		writecommand_cont(ILI9341_RAMWR);
 		uint8_t xr, yr;
@@ -1618,7 +1618,7 @@ void ILI9341_t3::drawFontBits(uint32_t bits, uint32_t numbits, uint32_t x, uint3
 #endif
 #if 1
 	if (bits == 0) return;
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	int w = 0;
 	do {
 		uint32_t x1 = x;
@@ -1758,7 +1758,7 @@ uint8_t ILI9341_t3::getRotation(void) {
 }
 
 void ILI9341_t3::sleep(bool enable) {
-	beginSPITransaction();
+	beginSPITransaction(_clock);
 	if (enable) {
 		writecommand_cont(ILI9341_DISPOFF);		
 		writecommand_last(ILI9341_SLPIN);	

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -182,6 +182,7 @@ class ILI9341_t3 : public Print
 	ILI9341_t3(uint8_t _CS, uint8_t _DC, uint8_t _RST = 255, uint8_t _MOSI=11, uint8_t _SCLK=13, uint8_t _MISO=12);
 	void begin(void);
   	void sleep(bool enable);		
+        void setClock(unsigned long clk) { _clock = clk;}
 	void pushColor(uint16_t color);
 	void fillScreen(uint16_t color);
 	void drawPixel(int16_t x, int16_t y, uint16_t color);
@@ -295,6 +296,7 @@ class ILI9341_t3 : public Print
 	int16_t strPixelLen(char * str);
 
  protected:
+        unsigned long _clock = ILI9341_SPICLOCK;
 	int16_t _width, _height; // Display w/h as modified by current rotation
 	int16_t  cursor_x, cursor_y;
 	uint16_t textcolor, textbgcolor;


### PR DESCRIPTION
The original class used a fixed SPI speed of 30Mhz. This is a reasonable / safe default, but most ILI9341 LCDs are capable of running much faster. I added a new public method "setClock" which allows you to set different speeds. My Teensy 4.1 on a perfboard with 10cm wires to a generic 2.8" LCD is able to run reliably at 80Mhz. The performance test (with my addition of a proportional font test) gives the following results:

ILI9341 Test!
Display Power Mode: 0x0
MADCTL Mode: 0x0
Pixel Format: 0x0
Image Format: 0x0
Self Diagnostic: 0x0
Benchmark                Time (microseconds)
Screen fill              78257
Text                     5114
Proportional Text        8574
Lines                    36802
Horiz/Vert Lines         6735
Rectangles (outline)     4431
Rectangles (filled)      161337
Circles (filled)         31221
Circles (outline)        27779
Triangles (outline)      8427
Triangles (filled)       58376
Rounded rects (outline)  12564
Rounded rects (filled)   180646
Done!
