### PR TITLE
move the #define of swap from header to cpp file

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -50,6 +50,10 @@
 
 #include "ILI9341_t3.h"
 #include <SPI.h>
+#ifndef swap
+#define swap(a, b) { typeof(a) t = a; a = b; b = t; }
+#endif
+
 
 // Teensy 3.1 can only generate 30 MHz SPI when running at 120 MHz (overclock)
 // At all other speeds, SPI.beginTransaction() will use the fastest available clock

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -553,10 +553,6 @@ class ILI9341_t3 : public Print
 	void drawFontBits(uint32_t bits, uint32_t numbits, uint32_t x, uint32_t y, uint32_t repeat);
 };
 
-#ifndef swap
-#define swap(a, b) { typeof(a) t = a; a = b; b = t; }
-#endif
-
 // To avoid conflict when also using Adafruit_GFX or any Adafruit library
 // which depends on Adafruit_GFX, #include the Adafruit library *BEFORE*
 // you #include ILI9341_t3.h.


### PR DESCRIPTION
There have been reports of programs not compiling as they may include some other header file that defines swap in conflict with the one here.

And as this one is not used in the header but only in the .cpp file and none of the examples use, it.  It feels safe to simply move it to .cpp file.

graphictest.ino builds fine with this change

Note this is in answer to issue #62 