### PR TITLE
getFont function added

### DIFF
--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -285,7 +285,7 @@ class ILI9341_t3 : public Print
 	void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
 	int16_t getCursorX(void) const { return cursor_x; }
 	int16_t getCursorY(void) const { return cursor_y; }
-	void setFont(const ILI9341_t3_font_t &f) { font = &f; active_font = font;}
+	void setFont(const ILI9341_t3_font_t &f) { font = &f; }
 	const ILI9341_t3_font_t* getFont() {return font;} 
 	void setFontAdafruit(void) { font = NULL; }
 	void drawFontChar(unsigned int c);

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -285,7 +285,8 @@ class ILI9341_t3 : public Print
 	void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
 	int16_t getCursorX(void) const { return cursor_x; }
 	int16_t getCursorY(void) const { return cursor_y; }
-	void setFont(const ILI9341_t3_font_t &f) { font = &f; }
+	void setFont(const ILI9341_t3_font_t &f) { font = &f; active_font = font;}
+	const ILI9341_t3_font_t* getFont() {return font;} 
 	void setFontAdafruit(void) { font = NULL; }
 	void drawFontChar(unsigned int c);
 	void measureChar(uint8_t c, uint16_t* w, uint16_t* h);


### PR DESCRIPTION
I hope this might be considered useful. I needed this when jumping around different functions in a GUI and found that without knowing what the active font was in the driver, I was having to ensure I always set the font again explicitly after calling any function that also set the font.

Not sure what happens if setFont was never used in the first place?