### PR TITLE
Support for Landscape native ILI9341 modules, and RGB (vs BGR) modules.

### DIFF
--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -307,6 +307,10 @@ void ILI9341_t3::setBGR(bool b) {
     madctl_bgr = b ? MADCTL_BGR : MADCTL_RGB;
 }
 
+bool ILI9341_t3::getBGR() {
+    return madctl_bgr == MADCTL_BGR;
+}
+
 void ILI9341_t3::setLandscape(bool l) {
     if (l != getLandscape()) {
         int16_t tmp = native_width;

--- a/ILI9341_t3.cpp
+++ b/ILI9341_t3.cpp
@@ -58,9 +58,6 @@
 // Teensy 3.1 can only generate 30 MHz SPI when running at 120 MHz (overclock)
 // At all other speeds, SPI.beginTransaction() will use the fastest available clock
 
-#define WIDTH  ILI9341_TFTWIDTH
-#define HEIGHT ILI9341_TFTHEIGHT
-
 // Constructor when using hardware SPI.  Faster, but must use SPI pins
 // specific to each board type (e.g. 11,13 for Uno, 51,52 for Mega, etc.)
 ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst, uint8_t mosi, uint8_t sclk, uint8_t miso)
@@ -71,8 +68,10 @@ ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst, uint8_t mosi, uint8_
 	_mosi = mosi;
 	_sclk = sclk;
 	_miso = miso;
-	_width    = WIDTH;
-	_height   = HEIGHT;
+    native_width = ILI9341_TFTWIDTH;
+    native_height = ILI9341_TFTHEIGHT;
+	_width    = native_width;
+	_height   = native_height;
 	rotation  = 0;
 	cursor_y  = cursor_x    = 0;
 	textsize  = 1;
@@ -82,6 +81,7 @@ ILI9341_t3::ILI9341_t3(uint8_t cs, uint8_t dc, uint8_t rst, uint8_t mosi, uint8_
 	// Added to see how much impact actually using non hardware CS pin might be
     _cspinmask = 0;
     _csport = NULL;
+    setBGR();
 }
 
 void ILI9341_t3::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
@@ -278,29 +278,41 @@ void ILI9341_t3::setRotation(uint8_t m)
 	writecommand_cont(ILI9341_MADCTL);
 	switch (rotation) {
 	case 0:
-		writedata8_last(MADCTL_MX | MADCTL_BGR);
-		_width  = ILI9341_TFTWIDTH;
-		_height = ILI9341_TFTHEIGHT;
+		writedata8_last(MADCTL_MX | madctl_bgr);
+		_width  = native_width;
+		_height = native_height;
 		break;
 	case 1:
-		writedata8_last(MADCTL_MV | MADCTL_BGR);
-		_width  = ILI9341_TFTHEIGHT;
-		_height = ILI9341_TFTWIDTH;
+		writedata8_last(MADCTL_MV | madctl_bgr);
+		_width  = native_height;
+		_height = native_width;
 		break;
 	case 2:
-		writedata8_last(MADCTL_MY | MADCTL_BGR);
-		_width  = ILI9341_TFTWIDTH;
-		_height = ILI9341_TFTHEIGHT;
+		writedata8_last(MADCTL_MY | madctl_bgr);
+		_width  = native_width;
+		_height = native_height;
 		break;
 	case 3:
-		writedata8_last(MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR);
-		_width  = ILI9341_TFTHEIGHT;
-		_height = ILI9341_TFTWIDTH;
+		writedata8_last(MADCTL_MX | MADCTL_MY | MADCTL_MV | madctl_bgr);
+		_width  = native_height;
+		_height = native_width;
 		break;
 	}
 	endSPITransaction();
 	cursor_x = 0;
 	cursor_y = 0;
+}
+
+void ILI9341_t3::setBGR(bool b) {
+    madctl_bgr = b ? MADCTL_BGR : MADCTL_RGB;
+}
+
+void ILI9341_t3::setLandscape(bool l) {
+    if (l != getLandscape()) {
+        int16_t tmp = native_width;
+        native_width = native_height;
+        native_height = tmp;
+    }
 }
 
 void ILI9341_t3::setScroll(uint16_t offset)

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -195,6 +195,15 @@ class ILI9341_t3 : public Print
 	void fillScreenVGradient(uint16_t color1, uint16_t color2);
 	void fillScreenHGradient(uint16_t color1, uint16_t color2);
 
+    void setLandscape(bool l=true);
+    void setPortrait(bool p=true)   { setLandscape(!p); }
+    bool getLandscape()             { return native_width > native_height; }
+    bool getPortrait()              { return !getLandscape(); }
+    void setBGR(bool b=true);
+    void setRGB(bool r=true)        { setBGR(!r); }
+    bool getBGR()                   { return madctl_bgr; }
+    bool getRGB()                   { return !madctl_bgr; }
+
 	void setRotation(uint8_t r);
 	void setScroll(uint16_t offset);
 	void invertDisplay(boolean i);
@@ -299,6 +308,7 @@ class ILI9341_t3 : public Print
  protected:
         unsigned long _clock = ILI9341_SPICLOCK;
 	int16_t _width, _height; // Display w/h as modified by current rotation
+    int16_t native_width, native_height;
 	int16_t  cursor_x, cursor_y;
 	uint16_t textcolor, textbgcolor;
 	uint8_t textsize, rotation;
@@ -309,6 +319,8 @@ class ILI9341_t3 : public Print
   	uint8_t _cs, _dc;
 	uint8_t pcs_data, pcs_command;
 	uint8_t _miso, _mosi, _sclk;
+    uint8_t madctl_bgr;
+
 	// add support to allow only one hardware CS (used for dc)
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
     uint32_t _cspinmask;

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -176,9 +176,9 @@ typedef struct {
 #define ILI9341_SPICLOCK 30000000
 #define ILI9341_SPICLOCK_READ 6500000
 
-#ifndef swap
-#define swap(a, b) { typeof(a) t = a; a = b; b = t; }
-#endif
+//#ifndef swap
+//#define swap(a, b) { typeof(a) t = a; a = b; b = t; }
+//#endif
 
 class ILI9341_t3 : public Print
 {

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -176,6 +176,10 @@ typedef struct {
 #define ILI9341_SPICLOCK 30000000
 #define ILI9341_SPICLOCK_READ 6500000
 
+#ifndef swap
+#define swap(a, b) { typeof(a) t = a; a = b; b = t; }
+#endif
+
 class ILI9341_t3 : public Print
 {
   public:

--- a/ILI9341_t3.h
+++ b/ILI9341_t3.h
@@ -201,7 +201,7 @@ class ILI9341_t3 : public Print
     bool getPortrait()              { return !getLandscape(); }
     void setBGR(bool b=true);
     void setRGB(bool r=true)        { setBGR(!r); }
-    bool getBGR()                   { return madctl_bgr; }
+    bool getBGR();
     bool getRGB()                   { return !madctl_bgr; }
 
 	void setRotation(uint8_t r);


### PR DESCRIPTION
I bought some cheap ILI9341 modules off eBay and they were landscape instead of portrait, and they RGB instead of BGR.  This PR provide support for both these differences.

This PR is backwards compatible; with no changes to your user code, this module operates exactly as before.

But if you've got a landscape native module, call setLandscape() then setRotation() to apply the change.

Similarly, if you've got an RGB native module, call setRGB() then setRotation() to apply the change.  (It's coincidence that both these changes are set at the same time by setRotation().)